### PR TITLE
Update local source SHIP

### DIFF
--- a/ships/0016-enable-local-source-code-support.md
+++ b/ships/0016-enable-local-source-code-support.md
@@ -115,7 +115,7 @@ The API changes should consider the following features:
 
 - **Ability to ensure reproducible Builds for bundle images**: Users should be able to verify if source code corresponds to a particular bundle image. To achieve this we can apply the pattern of reproducible builds, by pinning images timestamps to a particular time in the past. An example of the concept on reproducible builds is explained in [here](https://reproducible-builds.org/).
 
-- **Ability to specify particular directories that should not be bundled**: Users should be able to signalize using a `.shpignore` file, which directories to not be included in the bundle, e.g. _/vendor_. Reasonable defaults like _.github_ should be in place. Syntax should be similar/compatible with to the definitions in a `.gitignore` or `.dockerignore` file.
+- **Ability to specify particular directories that should not be bundled**: Users should be able to signalize using a `.shpignore` file, which directories not to include in the bundle, e.g. _/vendor_. Reasonable defaults like _.github_ should be in place. Syntax should be similar/compatible with the definitions in a `.gitignore` or `.dockerignore` file.
 
 ### Proposal 01: API modifications
 

--- a/ships/0016-enable-local-source-code-support.md
+++ b/ships/0016-enable-local-source-code-support.md
@@ -34,14 +34,15 @@ replaces:
 
 ## Summary
 
-Enable Shipwright users to build images from local source code, without the need of involving a Git repository service ( _e.g Github, Gitlab_ ).
+Enable Shipwright users to build images from local source code, without the need of involving a Git repository service (_e.g GitHub, GitLab_).
 
-Enabling local source code requires a coordination of work between [Shipwright/CLI](https://github.com/shipwright-io/cli) and [Shipwright/Build](https://github.com/shipwright-io/build), where the first one implements a bundle mechanism to push the source code into a self-extracted image and the second one exposes changes in the Build API and embeds the self-extracted image on runtime ( _prepended step_ ) inside the strategies.
+Enabling local source code requires a coordination of work between [Shipwright/CLI](https://github.com/shipwright-io/cli) and [Shipwright/Build](https://github.com/shipwright-io/build), where the first one implements a bundle mechanism to push the source code into a bundle image and the second one exposes changes in the Build API and embeds the bundle image on runtime (_source step_) inside the strategies.
+
 ## Motivation
 
 There are several reasons for the need of local source code:
 
-- **Development Mode Support**: Provide developers the ability to build container images while working on development mode, without forcing them to _commit/push_ changes to their related version control system ( _git_ ). This should also enable any workflow using Shipwright to provide a full end-to-end flow, where developers can build and deploy from their local workstation.
+- **Development Mode Support**: Provide developers the ability to build container images while working on development mode, without forcing them to _commit/push_ changes to their related version control system (_git_). This should also enable any workflow using Shipwright to provide a full end-to-end flow, where developers can build and deploy from their local workstation.
 
 - **Closing The Gaps**: Local source code support inlines with the continuous effort on improving the developer experience. There are different vendors or projects that indirectly support this feature. A popular example is [Cloud Foundry](https://docs.cloudfoundry.org/devguide/deploy-apps/deploy-app.html) with the `cf push` experience, enabling developers to build and deploy any application from local source code. Also [Kf](https://cloud.google.com/migrate/kf/docs/2.3/quickstart) provides the same developer experience, but it runs on Kubernetes.
 
@@ -76,33 +77,31 @@ This EP is well aware of all potential changes for the Build API, such as:
 - [Remote Artifacts](https://github.com/shipwright-io/build/blob/master/docs/proposals/remote-artifacts.md)
 - [Build Inputs Overhaul](https://github.com/shipwright-io/build/pull/652)
 
-Due to the state of the Remote Artifacts ( _exists in the API but is not yet fully functional_ ) feature and the uncertainty of the Build Inputs Overhaul proposal, this EP proposes to do the following changes in the current state of the Build API, meaning under `spec.source`.
+Due to the state of the Remote Artifacts (_exists in the API but is not yet fully functional_) feature and the uncertainty of the Build Inputs Overhaul proposal, this EP proposes to do the following changes in the current state of the Build API, meaning under `spec.source`.
 
 ### Local Source via Bundles
 
-The Bundle mechanism has it´s origins from this [Bundles](https://github.com/mattmoor/mink/tree/master/pkg/bundles) package and it´s based on the premise that if a user is pushing a container image to a container registry, then workflows could use the same approach to push the local source code, and pull it at a later stage during the building image mechanism.
+The Bundle mechanism has its origins from this [Bundles](https://github.com/mattmoor/mink/tree/master/pkg/bundles) package and it´s based on the premise that if a user is pushing a container image to a container registry, then workflows could use the same approach to push the local source code, and pull it at a later stage during the building image mechanism.
 
 The Bundle mechanism executes the following:
 
-- [1] Takes the source code from a local directory.
-- [2] Build a container image that can self-extracted on runtime.
-- [3] Push the container image with the source code into a container registry, making it available for further usages.
-- [4] The Build controller on signalization of local source code feature, will prepend a step with the bundle image generated in [3] on the Strategy steps, as a replacement for the current image that pulls the source code from git.
+1. Takes the source code from a local directory.
+1. Build a container image storing the files from the local directory.
+1. Push the container image with the source code into a container registry, making it available for further usages.
+1. The Build controller on signalization of local source code feature, will prepend a step with the bundle image generated in [3] on the Strategy steps, as a replacement for the current image that pulls the source code from Git.
 
-_Note_: To bundle the source code, an entity ( _Shipwright CLI_ ) will require to run code that will take the local source code from the user and put it inside a container image.
+_Note_: To bundle the source code, an entity (_Shipwright CLI_) will require to run code that will take the local source code from the user and put it inside a container image.
 
-_Note_: On runtime, when a Shipwright BuildRun is executing, that container image will be pulled and should self-extract its bundle, making the source code available ( _placed on a shared volume_ ) for other containers ( _like BuildKit, Kaniko, et al._ ) to use it.
+_Note_: On runtime, when a Shipwright BuildRun is executing, that container image will be pulled and should extract its bundle, making the source code available (_placed on a shared volume_) for other containers (_like BuildKit, Kaniko, et al._) to use it.
 
 _Note_: Any workflow using Shipwright that intends to provide support for local source code will require to re-use the Shipwright/CLI implementation or implement a standalone one.
 
-### API Changes
-
 The changes in the API will provide users the following functionalities:
 
-- [1] Specify from where ( _local directory_ ) to build a container image that will bundle the source code and that will self-extract its contents at runtime. Also known as `bundle` image.
-- [2] Specify an existing container image to use, for pulling the source code.
+1. Specify from where (_local directory_) to build a container image that will bundle the source code and that will extract its contents at runtime. Also known as `bundle` image.
+1. Specify an existing container image to use, for pulling the source code.
 
-This EP is merelely concentrated on [1], but will make [2] easily to implement at a later stage.
+This EP is merely concentrated on [1], but will make [2] easily to implement at a later stage.
 
 The API changes should consider the following features:
 
@@ -116,39 +115,37 @@ The API changes should consider the following features:
 
 - **Ability to ensure reproducible Builds for bundle images**: Users should be able to verify if source code corresponds to a particular bundle image. To achieve this we can apply the pattern of reproducible builds, by pinning images timestamps to a particular time in the past. An example of the concept on reproducible builds is explained in [here](https://reproducible-builds.org/).
 
-- **Ability to specify particular directories that should not be bundle**: Users should be able to signalize which directories to not bundle, e.g. _/vendor_ . Reasonable defaults like _.github_ should be in place. Similar to the definitions under a `.gitignore` or `.dockerignore` file.
+- **Ability to specify particular directories that should not be bundled**: Users should be able to signalize using a `.shpignore` file, which directories to not be included in the bundle, e.g. _/vendor_. Reasonable defaults like _.github_ should be in place. Syntax should be similar/compatible with to the definitions in a `.gitignore` or `.dockerignore` file.
 
 ### Proposal 01: API modifications
 
 > Extend `spec.source`
 
- Introduce `spec.source.container`, which should host all the necessary metadata to signalize the usage of local source code, this should be a go `struct` which indicates what to bundle.
+ Introduce `spec.source.bundleContainer`, which should host all the necessary metadata to signalize the usage of local source code, this should be a go `struct` which indicates what to bundle.
 
- See an API [example](https://github.com/qu1queee/build/blob/qu1queee/local_source/pkg/apis/build/v1alpha1/source.go#L46-L59) . The [Container](https://github.com/qu1queee/build/blob/qu1queee/local_source/pkg/apis/build/v1alpha1/source.go#L46) struct should **at least** allow users to define the following:
+ See an API [example](https://github.com/qu1queee/build/blob/qu1queee/local_source/pkg/apis/build/v1alpha1/source.go#L46-L59). The [Container](https://github.com/qu1queee/build/blob/qu1queee/local_source/pkg/apis/build/v1alpha1/source.go#L46) struct should **at least** allow users to define the following:
 
- 1. A `spec.source.container.image` mandatory [field](https://github.com/qu1queee/build/blob/qu1queee/local_source/pkg/apis/build/v1alpha1/source.go#L49) for specifying the container image endpoint, registry and repository to build. We should support only image references by digest. If we would like to support image references by tag, then we should consider surfacing the digest of the image under the BuildRun Status fields.
- We expect Shipwright/CLI to push this image and Shipwright/Build will pull it and run its entrypoint ( _and never push it_ ).
+1. A `spec.source.bundleContainer.image` mandatory [field](https://github.com/qu1queee/build/blob/qu1queee/local_source/pkg/apis/build/v1alpha1/source.go#L49) for specifying the container image endpoint, registry and repository to build. We should support only image references by digest. If we would like to support image references by tag, then we should consider surfacing the digest of the image under the BuildRun Status fields.
 
- On top of that, to fulfill the features defined above, we could extend the API to include:
+We expect Shipwright/CLI to push this image and Shipwright/Build will pull it and run its entrypoint (_and never push it_).
 
- 2. A `spec.source.container.pruneBundle` optional field. To signalize the deletion of the bundle image at the very end of the execution of a strategy. Should be disable by _default_.
+Since the credentials field is universal, it works for both Git sources as well as bundles stored in the container registry. Therefore: The implementation will reuse the `spec.source.credentials`.
 
- _Note_: To be decided later on how to allow authentication for container images as a source of code via `spec.source.container`. At the moment some of the options are:
+Disregarded authentication options:
 
-   - Reuse the `spec.source.credentials`. However this is intended only for authentication to git, for pulling source code.
-   - Reuse the `spec.output.credentials`. However the scenario where the authentication applies to both pulling ( _image with code_ ) and pushing ( _final container image_ ), might be uncommon.
-   - Add a new `spec.source.container.credentials`. Might not be needed in all cases, as one could pull a bundle that is publicly available.
+- Reuse the `spec.output.credentials`. However the scenario where the authentication applies to both pulling (_image with code_) and pushing (_final container image_), might be uncommon.
+- Add a new `spec.source.bundleContainer.credentials`. Might not be needed in all cases, as one could pull a bundle that is publicly available.
 
 > Make `spec.source.url` a none mandatory field
 
- 1. This was done thinking on assets only hosted in `git`, which no longer holds true. See an [example](https://github.com/qu1queee/build/blob/qu1queee/local_source/pkg/apis/build/v1alpha1/source.go#L19-L20).
+1. This was done thinking on assets only hosted in `git`, which no longer holds true. See an [example](https://github.com/qu1queee/build/blob/qu1queee/local_source/pkg/apis/build/v1alpha1/source.go#L19-L20).
 
 ### Proposal 02: Runtime Modifications
 
 > Ensure that the bundle image is prepended as the first step in the Build strategies.
 
-  1. When `spec.source.container.image` is defined, we should  not longer create the Tekton Input PipelineResource. We do this today, to tell Tekton that we want to pull source from a git repository, which ends as a container that pulls it. See an [example](https://github.com/qu1queee/build/blob/qu1queee/local_source/pkg/reconciler/buildrun/resources/taskrun.go#L184-L185) on future changes. It might happen that at the time of implementing this EP we do not longer use the git PipelineResource but rather our in-house custom [image](https://github.com/shipwright-io/build/pull/751). For both scenarios, we will need to ensure that the `git` image is not present any longer on the steps.
-  
+  1. When `spec.source.bundleContainer.image` is defined, we should  not longer create the Tekton Input PipelineResource. We do this today, to tell Tekton that we want to pull source from a git repository, which ends as a container that pulls it. See an [example](https://github.com/qu1queee/build/blob/qu1queee/local_source/pkg/reconciler/buildrun/resources/taskrun.go#L184-L185) on future changes. It might happen that at the time of implementing this EP we do not longer use the git PipelineResource but rather our in-house custom [image](https://github.com/shipwright-io/build/pull/751). For both scenarios, we will need to ensure that the `git` image is not present any longer on the steps.
+
   2. We need to **prepend** a new step in our Task step definition, which will pull our local source code from the bundle image. See an [example](https://github.com/qu1queee/build/blob/qu1queee/local_source/pkg/reconciler/buildrun/resources/taskrun.go#L171-L186). Important to notice, the image to pull will be a self-extracted image, therefore the `workingDir` container definition should be under `/workspace/source`, which is a well-known path in the Shipwright strategies, where source code is expected to be. It might happen that at the time of implementing this EP we do not longer use `/workspace/source` as we are continuously deprecating in Shipwright some of the custom Tekton behaviours. We will need to ensure the bundle image extracts the code on the path where Shipwright custom images expect it to be.
 
   3. If authentication was specified for the bundle image, we need to ensure we have that mounted in the pod either in the form of a secret or a service-account. _Note_: We eventually might stop using Tekton service-account support in TaskRun resources, this will force us to rely on something like `spec.imagePullSecrets` at the pod level.
@@ -165,28 +162,27 @@ The API changes should consider the following features:
 
 _Note_: To be define where to host the image source code, but preferably in the CLI side.
 
-### Proposal 04: Bundle Mechanism ( _CLI_ )
+### Proposal 04: Bundle Mechanism (_CLI_)
 
-> Introduce a bundle `pkg`in the CLI side
+> Introduce a bundle `pkg` in the CLI side
 
- See an [example](https://github.com/qu1queee/cli/tree/qu1queee/crud_cmd/pkg/shp/bundle). The current examples provided in this EP, re-use the existing [Bundles](https://github.com/mattmoor/mink/tree/master/pkg/bundles) package, but for Shipwright/CLI we require to have our own custom implementation.
+See an [example](https://github.com/qu1queee/cli/tree/qu1queee/crud_cmd/pkg/shp/bundle). The current examples provided in this EP, re-use the existing [Bundles](https://github.com/mattmoor/mink/tree/master/pkg/bundles) package, but for Shipwright/CLI we require to have our own custom implementation.
 
- 1. Develop a Bundle pkg that can walk a given directory and produce a consumable tarball for later usage.
+1. Develop a Bundle pkg that can walk a given directory and produce a consumable tarball for later usage.
 
- 2. The above bundle pkg should append the tarball layer with the base image on Proposal 03 and produce the final bundle image. _Note_: We should ensure that the final bundle image is compatible with the Kubernetes cluster architecture.
+1. The above bundle pkg should append the tarball layer with the base image on Proposal 03 and produce the final bundle image. _Note_: We should ensure that the final bundle image is compatible with the Kubernetes cluster architecture.
 
- 3. Ensure that the Bundle pkg can authenticate when pushing the bundle image to the registry. This will require local authentication to a registry. For example a `docker login` in the user workstation.
+1. Ensure that the Bundle pkg can authenticate when pushing the bundle image to the registry. This will require local authentication to a registry. For example a `docker login` in the user workstation.
 
- 4. Ensure that the Bundle pkg have reasonable defaults on directories that should not be included in the generated tarball.
+1. Ensure that the Bundle pkg have reasonable defaults on directories that should not be included in the generated tarball.
 
- 5. Ensure that on image creation, we can follow the reproducible build pattern. By pinning image timestamps to a fixed date.
+1. Ensure that on image creation, we can follow the reproducible build pattern. By pinning image timestamps to a fixed date.
 
- 6. Modify the existing CLI subcommand to surface the usage of local source code. If this is the case, it should bundle and create an image. See an [example](https://github.com/qu1queee/cli/blob/qu1queee/crud_cmd/pkg/shp/cmd/build/create.go#L115-L134). Ideally the subcommand to trigger the usage of the local source code, should support the following features:
+1. Modify the existing CLI subcommand to surface the usage of local source code. If this is the case, it should bundle and create an image. See an [example](https://github.com/qu1queee/cli/blob/qu1queee/crud_cmd/pkg/shp/cmd/build/create.go#L115-L134). Ideally the subcommand to trigger the usage of the local source code, should support the following features:
 
-   - A flag to specified an absolute `path` where the local source code is located in the local workstation.
-   - We should consider having a configuration file, where reasonable defaults for the `shp` subcommands and flags can be specified.
-   - A flag to provide a list of directories that we shouldn´t bundle. For example a `vendor` folder in a go project.
-
+    - A flag to specified an absolute `path` where the local source code is located in the local workstation.
+    - We should consider having a configuration file, where reasonable defaults for the `shp` subcommands and flags can be specified.
+    - A flag to provide a list of directories that we shouldn´t bundle. For example a `vendor` folder in a go project.
 
 ### User Stories [optional]
 
@@ -201,18 +197,28 @@ Therefore, users should be able to signalize this feature via:
 ```yaml
 spec:
   source:
-    container:
+    bundleContainer:
       image: docker.io/<registry-repository>/abundle@sha256:3235326357dfb65f17 # Note: full digest incomplete
 ```
 
 #### As a Shipwright User I want to build images in Development mode from my local Dockerfile or plain source code
 
-Users should only need to specify the mandatory fields under `spec.source.container` without modifying their existing strategies of choice. Local source code feature should work out of the box with different tools, like Kaniko, BuildKit, Buildpacks, et al.
+Users should only need to specify the mandatory fields under `spec.source.bundleContainer` without modifying their existing strategies of choice. Local source code feature should work out of the box with different tools, like Kaniko, BuildKit, Buildpacks, et al.
 
 This will be done via Shipwright/CLI in the form of:
 
 ```sh
-shp build create a-build --local-path "/absolute-path/src/github.com/shipwright-io/sample-go/docker-build" --output-image "docker.io/<registry-repository>/img:latest" --strategy "kaniko"
+shp build create my-local-build \
+  --strategy-name=kaniko \
+  --source-bundle-image=docker.io/org/source:latest \
+  --source-credentials-secret regcred \
+  --dockerfile=Dockerfile \
+  --output-image=docker.io/org/my-app \
+  --output-credentials-secret=regcred
+
+shp buildrun create \
+  --buildref-name my-local-build \
+  --source-directory ~/git/sample-go
 ```
 
 _Note_: The above is just an example on how the CLI might look like.
@@ -225,26 +231,11 @@ We want to provide trust to users when building bundle images with their source 
 
 We want to allow users to signalize the desire of pruning a bundle image that was used for building their application container image.
 
-Adding `pruneBundle` should ensure a mechanism for deleting `docker.io/<registry-repository>/bundle:latest`.
+Initially, the idea was to include `pruneBundle` as part of the Build spec to indicate the deletion. However, the pragmatic solution is to let the CLI handle the deletion for multiple reasons:
 
-```yaml
----
-apiVersion: shipwright.io/v1alpha1
-kind: Build
-metadata:
-  name: a-kaniko-build
-spec:
-  source:
-    container:
-      image: docker.io/<registry-repository>/bundle:latest
-      pruneBundle: true # Disable by default
-  strategy:
-    name: kaniko
-    kind: ClusterBuildStrategy
-  output: ...
-```
-
-The above Build definition should ensure that a step in our [TaskSpec](https://github.com/qu1queee/build/blob/qu1queee/local_source/pkg/reconciler/buildrun/resources/taskrun.go#L59) definition is appended, which will ensure a pruning of the image in the related container registry.
+- The CLI is the entity that put the bundle in the container registry in the first place, so it is a fact that it has the rights to delete the image.
+- It provides more flexibility on deciding in which case the bundle image should be deleted.
+- Reduce the complexity of Shipwright as there is no need for an optional post-processing step and also no requirement to supply additional credentials for bundle image deletion.
 
 _Note_: Supporting multiple registry providers might be too complicated and different alternatives should be considering for pruning.
 
@@ -260,34 +251,29 @@ The following provides an example of core concepts and how do they relate:
 
    ```sh
    shp build create "local-build" \
-   --output-image "docker.io/<your-registry-repository>/local-go-kaniko:latest" \
-   --strategy "kaniko" \
-   --local-path "<your-absolute-local-path>/github.com/shipwright-io/sample-go/docker-build" \
-   --bundle-image "docker.io/<your-registry-repository>/latest-bundle:latest"
+     --output-image "docker.io/<your-registry-repository>/local-go-kaniko:latest" \
+     --strategy-name "kaniko" \
+     --source-bundle-image "docker.io/<your-registry-repository>/latest-bundle:latest"
    ```
 
-   Users are required to define two flags on the `create` subcommand:
-
-   - `--bundle-image`: Where to put the bundle. Note that this could have a reasonable default, based on the value of `--output-image`.
-   - `--local-path`: From where in the local workstation to retrieve the source code.
-
-   The SHP CLI will then:
-
-   - a. Build the bundle image based on `--bundle-image` if specified, if not a reasonable default will be used.
-   - b. Create a Build and specify under `spec.source.container.image` a reference to the image create in a), that includes a `digest`.
+   The SHP CLI will then: Create a Build and specify under `spec.source.bundleContainer.image` a reference to the image create in a), that includes a `digest`.
 
 2. Users should trigger the created Build via the SHP CLI, see example:
 
    ```sh
-   shp build run "local-build"
+   shp buildrun create \
+     --buildref-name local-build \
+     --source-directory ~/git/sample-go
    ```
+
+   By default, the current working directory is used. However, this can be overwritten using `--source-directory` command line flag.
+
+   The SHP CLI will then: Build the bundle image, push it to the container registry, and create a buildrun for the provided build.
 
 _Note_: There is a prototype for educational purposes that can be tested if desire, see the related [documentation](https://github.com/qu1queee/cli/blob/qu1queee/crud_cmd/README.md). This uses the following two branches:
 
 - Changes in Shipwright/Build, see [branch](https://github.com/qu1queee/build/tree/qu1queee/local_source)
 - Changes in Shipwright/CLI, see [branch](https://github.com/qu1queee/cli/tree/qu1queee/crud_cmd)
-
-
 
 ### Risks and Mitigations
 


### PR DESCRIPTION
Explain removal of `pruneBuild`.

Correct field names with the actual ones being used in the implementation.

Update example CLI calls.

Fix Markdown linter issues.