### PR TITLE
ADD MAINTAINERS file

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,14 @@
+# Maintainers
+
+The current Maintainers Group for the Shipwright Project consists of:
+
+| Name              | Employer | GitHub ID                                             | Responsibilities           |
+| ----------------- | -------- | ----------------------------------------------------- | -------------------------- |
+| Sascha Schwarze   | IBM      | [SaschaSchwarze0](https://github.com/SaschaSchwarze0) | Administrator, Maintainer  |
+| Adam Kaplan       | Red Hat   | [adambkaplan](https://github.com/adambkaplan)        | Administrator, Maintainer  |
+| Enrique Encalada  | IBM      | [qu1queee](https://github.com/qu1queee)               | Administrator, Maintainer  |
+
+
+This list must be kept in sync with the [CNCF Project Maintainers list](https://github.com/cncf/foundation/blob/master/project-maintainers.csv).
+
+The Project Governance and roles definition is under development. This document will be updated in the future with a link to the governance file.


### PR DESCRIPTION
# Changes

Related to https://github.com/shipwright-io/community/issues/240

This document is based on https://contribute.cncf.io/maintainers/templates/maintainers/ . Although we have not yet defined roles, I'm adding in the list the `admin and maintainer`. Once we define the governance doc, I expect those two roles to be there, per [Github Roles and Responsabilities](https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/repository-roles-for-an-organization#repository-access-for-each-permission-level)

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```

