### PR TITLE
Add Project Roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ Documentation is spread across the code repositories, and is consolidated in the
 Enhancements to Shipwright are discussed through the Shipwright Improvement Proposal (SHIP) process.
 If you have an idea that you want to submit to Shipwright, please read the proposal process [guidelines](/ships/README.md).
 
+## Roadmap
+
+Want to know what we are working on? Start by taking a look at the project [roadmap](/ROADMAP.md).
+
 ## Icons and logos
 
 Graphic assets for the project, such as official logos, are located under the `assets` directory.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,25 @@
+# Community-Driven Roadmap
+
+Shipwright's detailed roadmap can be found on the
+[Shipwright Overview GitHub Project](https://github.com/orgs/shipwright-io/projects/6). All
+repositories are currently tied to the release cycle of the core
+[build](https://github.com/shipwright-io/build) sub-project. Shipwright aims to issue minor
+releases quarterly, using the same major and minor semantic version across repositories.
+
+## 2025 Release Schedule
+
+Below is the tentative release schedule for 2025. Actual release dates may vary based on community
+availability and release stability.
+
+- v0.15: week of 2025-02-28
+  - Kubernetes version: 1.32
+  - Tekton Pipelines version: 0.65
+- v0.16: week of 2025-05-30
+  - Kubernetes version: 1.33
+  - Tekton Pipelines version: 0.68
+- v0.17: week of 2025-08-29
+  - Kubernetes version: 1.33
+  - Tekton Pipelines version: 0.71
+- v0.18: week of 2025-11-28
+  - Kubernetes version: 1.34
+  - Tekton Pipelines version: 0.74


### PR DESCRIPTION
# Changes

Adding a separate document to hold project roadmap information. This includes a link to the main GitHub project board we currently use during backlog refinement sessions.

The roadmap also includes a proposed quarterly release schedule for 2025 that aligns with Tekton's anticipated LTS release schedule (+1 month). The anticipated base Kubernetes and Tekton Pipeline versions are listed - these can be subject to change at the discretion of the `build` sub-project maintainers.

/kind documentation

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
