### PR TITLE
doc: Shipwright Webhook Feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ Documentation is spread across the code repositories, and is consolidated in the
   * Weekly Community Update - every Monday, 9AM Eastern Time
   * Bi-weekly Backlog Refinement - every other Thursday, 10AM Eastern Time
 
+### External Integrations
+
+Do you want to automatically track what Shipwright is working on? Email the
+[Shipwright Admins](mailto:shipwright-admins@lists.cncf.io) to request access to Shipwright's webhook feed.
+
 ## SHIPs
 
 Enhancements to Shipwright are discussed through the Shipwright Improvement Proposal (SHIP) process.


### PR DESCRIPTION
# Changes

This community README update serves as an announcement that any community member can receive automated notifications of Shipwright activity through GitHub's webhook feed mechanism. For now, anyone can request access by emailing the project admins
(shipwright-admins@lists.cncf.io). Maintainers with org-wide write permission will then need to work with the requestor to obtain the desired endpoint, webhook secret, payload format, and types of events to receive. In the future, we can gather some of this information up front through a GitHub issue template (obviously not the secret - that should be exchanged through a proper private channel).

This was prompted by previous work I did to send GitHub issue and PR events to Fedora's GitHub2FedMsg bus [1]. I had set this up on behalf of Red Hat to sync data from GitHub to Red Hat's issue tracker. There is no compelling reason to restrict this sort of feed to just Red Hat; any community member who wants to track our project work in their own systems should be able to do so.

[1] https://github.com/fedora-infra/github2fedmsg

/kind documentation

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
