### PR TITLE
fix: update community meetings calendar link

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Documentation is spread across the code repositories, and is consolidated in the
 * Review our [Contributing Guide](https://github.com/shipwright-io/.github/blob/main/CONTRIBUTING.md).
 * Join our mailing lists for [users](https://lists.shipwright.io/archives/list/shipwright-users@lists.shipwright.io/) or [contributors](https://lists.shipwright.io/archives/list/shipwright-dev@lists.shipwright.io/)
 * Talk with us on the Kubernetes Slack - [#shipwright](https://kubernetes.slack.com/messages/shipwright) channel
-* Attend one of our community meetings - see our [public calendar](https://calendar.google.com/calendar/embed?src=shipwright-admin%40lists.shipwright.io&ctz=America%2FNew_York) for up to date information.
+* Attend one of our community meetings - see our [public calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/shipwright) for up to date information.
   * Weekly Community Update - every Monday, 9AM Eastern Time
   * Bi-weekly Backlog Refinement - every other Thursday, 10AM Eastern Time
 


### PR DESCRIPTION
# Changes

fix: update community meetings calendar link to https://zoom-lfx.platform.linuxfoundation.org/meetings/shipwright
