### PR TITLE
feat: Adopt Maintainer Council Governance

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,163 @@
+# Shipwright Project Governance
+
+The Shipwright project is dedicated to creating an extensible framework for
+building containers on Kubernetes. This governance document explains how the
+project is run.
+
+- [Values](#values)
+- [Maintainers](#maintainers)
+- [Becoming a Maintainer](#becoming-a-maintainer)
+- [Meetings](#meetings)
+- [CNCF Resources](#cncf-resources)
+- [Code of Conduct Enforcement](#code-of-conduct)
+- [Security Response Team](#security-response-team)
+- [Voting](#voting)
+- [Modifications](#modifying-this-charter)
+
+## Values
+
+Shipwright and its leadership embrace the following values:
+
+* Openness: Communication and decision-making happens in the open and is
+  discoverable for future reference. As much as possible, all discussions and
+  work take place in public forums and open repositories.
+
+* Fairness: All stakeholders have the opportunity to provide feedback and
+  submit contributions, which will be considered on their merits.
+
+* Community over Product or Company: Sustaining and growing our community takes
+  priority over shipping code or sponsors' organizational goals.  Each
+  contributor participates in the project as an individual.
+
+* Inclusivity: We innovate through different perspectives and skill sets, which
+  can only be accomplished in a welcoming and respectful environment.
+
+* Participation: Responsibilities within the project are earned through
+  participation, and there is a clear path up the contributor ladder into leadership
+  positions.
+
+## Maintainers
+
+Shipwright Maintainers have write access to the [shipwright-io GitHub organization](https://github.com/shipwright-io).
+They can merge their own patches or patches from others. Maintainers can also
+approve significant enhancements through the
+[Shipwright Improvement Proposal (SHIP)](./ships/README.md) process.
+
+The current maintainers can be found in [MAINTAINERS.md](./MAINTAINERS.md).
+Maintainers collectively manage the project's resources and contributors.
+
+This privilege is granted with some expectation of responsibility: maintainers
+are people who care about the Shipwright project and want to help it grow and
+improve. A maintainer is not just someone who can make changes, but someone who
+has demonstrated their ability to collaborate with the team, get the most
+knowledgeable people to review code and docs, contribute high-quality code, and
+follow through to fix issues (in code or tests).
+
+A maintainer is a contributor to the project's success and a citizen helping
+the project succeed.
+
+The collective team of all Maintainers is known as the Maintainer Council, which
+is the governing body for the project.
+
+### Becoming a Maintainer
+
+To become a Maintainer you need to demonstrate a high level of commitment to the
+project. This can include one or more of the following:
+
+* Participate in discussions, contributions, code and documentation reviews for
+  a period of 3 months or more.
+* Perform reviews for 3 non-trivial pull requests.
+* Contribute 3 non-trivial pull requests and have them merged OR be granted
+  "approver" permissions on a subproject.
+* Demonstrate ability to write quality code and/or documentation.
+* Demonstrate ability to collaborate with the rest of the community, including
+  adherence to community standards and processes.
+* Demonstrate understanding of the project's code base, coding style, and
+  documentation.
+  <!-- add any additional Maintainer requirements here -->
+
+A new Maintainer must be proposed by an existing maintainer by sending a message to the
+[shipwright-dev mailing list](https://lists.cncf.io/g/shipwright-dev)
+and adding this proposal to the next [community meeting agenda](https://docs.google.com/document/d/10tDPl_t2-7NcxmI1Iy50dIGPIRIdIUh8v6qp1iH3wLc/edit?usp%3Dsharing&sa=D&source=calendar&ust=1758976487834455&usg=AOvVaw3m02aZRC0mVMYy2ble3TSS).
+A simple majority vote of existing Maintainers approves the application.
+Maintainer nominations will be evaluated without prejudice to employer or
+demographics.
+
+Maintainers who are selected will be granted the necessary GitHub rights,
+and invited to the private admin and security mailing list.
+
+### Removing a Maintainer
+
+Maintainers may resign at any time if they feel that they will not be able to
+continue fulfilling their project duties.
+
+Maintainers may also be removed after being inactive, failure to fulfill their 
+Maintainer responsibilities, violating the Code of Conduct, or other reasons.
+Inactivity is defined as a period of very low or no activity in the project 
+for a year or more, with no definite schedule to return to full Maintainer 
+activity.
+
+A Maintainer may be removed at any time by a 2/3 vote of the remaining maintainers.
+
+Depending on the reason for removal, a Maintainer may be converted to Emeritus
+status.  Emeritus Maintainers will still be consulted on some project matters,
+and can be rapidly returned to Maintainer status if their availability changes.
+
+## Meetings
+
+Time zones permitting, Maintainers are expected to participate in the public
+community meeting, which occurs every Monday at 09:00 Eastern Time. 
+
+Maintainers will also have closed meetings in order to discuss security reports
+or Code of Conduct violations as necessary. Such meetings should be scheduled by
+any Maintainer on receipt of a security issue or CoC report. All current
+Maintainers must be invited to such closed meetings, except for any Maintainer
+who is accused of a CoC violation.
+
+## CNCF Resources
+
+Any Maintainer may suggest a request for CNCF resources, either in the
+[shipwright-dev mailing list](https://lists.cncf.io/g/shipwright-dev),
+or during a community meeting. A simple majority of Maintainers approves the
+request. The Maintainers may also choose to delegate working with the CNCF to
+non-Maintainer community members, who will then be added to the
+[CNCF's Maintainer List](https://github.com/cncf/foundation/blob/main/project-maintainers.csv)
+for that purpose.
+
+## Code of Conduct
+
+[Code of Conduct](https://github.com/shipwright-io/.github/blob/main/CODE_OF_CONDUCT.md)
+violations by community members will be discussed and resolved
+on the [shipwright-admins mailing list](mailto:shipwright-admins@lists.cncf.io).
+If a Maintainer is directly involved in the report, the Maintainers will instead
+designate two Maintainers to work with the CNCF Code of Conduct Committee in
+resolving it.
+
+## Security Response Team
+
+The Maintainers will appoint a Security Response Team to handle security reports.
+This committee may simply consist of the Maintainer Council themselves.  If this
+responsibility is delegated, the Maintainers will appoint a team of at least two 
+contributors to handle it.  The Maintainers will review who is assigned to this
+at least once a year.
+
+The Security Response Team is responsible for handling all reports of security
+holes and breaches according to the [security policy](https://github.com/shipwright-io/.github/blob/main/SECURITY.md).
+
+## Voting
+
+While most business in Shipwright is conducted by "[lazy consensus](https://community.apache.org/committers/lazyConsensus.html)", 
+periodically the Maintainers may need to vote on specific actions or changes.
+A vote can be taken on [shipwright-dev mailing list](https://lists.cncf.io/g/shipwright-dev) or
+[the private shipwright-admins mailing list](https://lists.cncf.io/g/shipwright-admins) for security or conduct matters.  
+Votes may also be taken at [the weekly community meeting](https://zoom-lfx.platform.linuxfoundation.org/meetings/shipwright?view=week).
+Any Maintainer may demand a vote be taken.
+
+Most votes require a simple majority of all Maintainers to succeed, except where
+otherwise noted. Two-thirds majority votes mean at least two-thirds of all 
+existing maintainers.
+
+## Modifying this Charter
+
+Changes to this Governance and its supporting documents may be approved by 
+a 2/3 vote of the Maintainers.


### PR DESCRIPTION
# Changes

Adding an official governance document, based on the CNCF "Maintainer Council" template. Shipwright has had a de-facto maintainer council since its inception; this document formalizes what has otherwise been a verbal agreement amongst the founder-maintainers. This change ensures the project has a clear path for new maintainers to join the project, and outlines maintainer responsibilities once accepted.

Fixes #243 

/kind feature

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Adopt "Maintainer Council" governance charter
```
