### PR TITLE
chore: mark adambkaplan emeritus approver

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -5,7 +5,6 @@ The current Maintainers Group for the Shipwright Project consists of:
 | Name              | Employer | GitHub ID                                             | Responsibilities           |
 | ----------------- | -------- | ----------------------------------------------------- | -------------------------- |
 | Sascha Schwarze   | IBM      | [SaschaSchwarze0](https://github.com/SaschaSchwarze0) | Administrator, Maintainer  |
-| Adam Kaplan       | Red Hat   | [adambkaplan](https://github.com/adambkaplan)        | Administrator, Maintainer  |
 | Enrique Encalada  | IBM      | [qu1queee](https://github.com/qu1queee)               | Administrator, Maintainer  |
 | Hasan Awad | Red Hat | [@hasanawad94](https://github.com/hasanawad94) | Administrator, Maintainer |
 
@@ -26,3 +25,13 @@ The current Approvers Group for the Shipwright Project consists of:
 
 Community members are eligible to graduate to the Maintainer and Approver groups in accordance with the project
 [Governance](./GOVERNANCE.md) and [Contributor Ladder](./CONTRIBUTOR-LADDER.md).
+
+# Emeritus Maintainers
+
+The following individuals have stepped down from active maintainer responsibilities but are recognized for their prior contributions to the project:
+
+| Name          | GitHub ID                                             | Former Responsibilities   |
+| ------------- | ----------------------------------------------------- | ------------------------- |
+| Adam Kaplan   | [adambkaplan](https://github.com/adambkaplan)         | Administrator, Maintainer |
+| Shoubhik Bose | [sbose78](https://github.com/sbose78)                 | Founder, Maintainer       |
+| Jason Hall    | [ImJasonH](https://github.com/ImJasonH)               | Founder, Maintainer       |

--- a/OWNERS
+++ b/OWNERS
@@ -1,17 +1,16 @@
 # The OWNERS file lists individuals who are allowed to approve pull requests by prow
 
 approvers:
-- adambkaplan
 - qu1queee
 - SaschaSchwarze0
 
 reviewers:
 - qu1queee
 - SaschaSchwarze0
-- adambkaplan
 - HeavyWombat
 
 emeritus_approvers:
+- adambkaplan # 2026-06-17
 - sbose78
 
 emeritus_reviewers:


### PR DESCRIPTION
# Changes

Remove adambkaplan from approvers and reviewers, add to emeritus_approvers, and move Adam Kaplan to the Emeritus Maintainers section in MAINTAINERS.md.

# Related Issue

N/A

# Type of PR

/kind documentation

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] Kind label has been set
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/.github/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Mark adambkaplan as emertius maintainer
```
