### PR TITLE
Move Hasan Awad to Emeritus Maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,7 +7,6 @@ The current Maintainers Group for the Shipwright Project consists of:
 | Sascha Schwarze   | IBM      | [SaschaSchwarze0](https://github.com/SaschaSchwarze0) | Administrator, Maintainer  |
 | Adam Kaplan       | Red Hat   | [adambkaplan](https://github.com/adambkaplan)        | Administrator, Maintainer  |
 | Enrique Encalada  | IBM      | [qu1queee](https://github.com/qu1queee)               | Administrator, Maintainer  |
-| Hasan Awad | Red Hat | [@hasanawad94](https://github.com/hasanawad94) | Administrator, Maintainer |
 
 This list must be kept in sync with the [CNCF Project Maintainers list](https://github.com/cncf/foundation/blob/master/project-maintainers.csv).
 
@@ -26,3 +25,10 @@ The current Approvers Group for the Shipwright Project consists of:
 
 Community members are eligible to graduate to the Maintainer and Approver groups in accordance with the project
 [Governance](./GOVERNANCE.md) and [Contributor Ladder](./CONTRIBUTOR-LADDER.md).
+
+
+# Emeritus Maintainers
+
+| Name              | Employer | GitHub ID                                             |
+| ----------------- | -------- | ----------------------------------------------------- |
+| Hasan Awad        | Red Hat  | [@hasanawad94](https://github.com/hasanawad94)        |


### PR DESCRIPTION


# Changes
As discussed in the community meeting, move Hasan
Awad to the Emeritus Maintainers group.

Reasons:
- There have been no contributions since leaving Red Hat.
- Multiple attempts to reach out did not receive a response.
- Sufficient time was given for a response before making this change.

This helps ensure that maintainer permissions are
limited to active project maintainers while
recognizing past contributions.

# Related Issue

<!-- Link the GitHub issue this PR addresses. Use "Fixes" to auto-close the issue on merge,
or "Related to" if the issue needs additional work. -->

Fixes #

/kind documentation

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] Kind label has been set
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/.github/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes


```release-note
NONE
```
